### PR TITLE
Add Time(), Before() and After() methods to Date type.

### DIFF
--- a/date.go
+++ b/date.go
@@ -63,6 +63,45 @@ func (v Date) DaysAgo() (Int64, error) {
 	return NewInt(int(time.Since(t).Hours() / 24)), nil
 }
 
+// Time returns a time.Time instance for this Date.
+func (v Date) Time() (time.Time, error) {
+	var t time.Time
+	if v.Nil() {
+		return t, errors.Errorf("value %v is not a valid date", v.v)
+	}
+	t, err := time.Parse("2006-01-02", v.String())
+	if err != nil {
+		return t, err
+	}
+	return t, nil
+}
+
+// Before reports whether the Date instance is before d.
+func (v Date) Before(d Date) (bool, error) {
+	t, err := v.Time()
+	if err != nil {
+		return false, err
+	}
+	u, err := d.Time()
+	if err != nil {
+		return false, err
+	}
+	return t.Before(u), nil
+}
+
+// Before reports whether the Date instance is after d.
+func (v Date) After(d Date) (bool, error) {
+	t, err := v.Time()
+	if err != nil {
+		return false, err
+	}
+	u, err := d.Time()
+	if err != nil {
+		return false, err
+	}
+	return t.After(u), nil
+}
+
 // String implements the fmt.Stringer interface
 func (v Date) String() string {
 	return v.v

--- a/date_test.go
+++ b/date_test.go
@@ -146,6 +146,136 @@ func daysAgo(days int) string {
 	return newTime.Format("2006-01-02")
 }
 
+func TestDate_Before(t *testing.T) {
+	tests := []struct {
+		name  string
+		this  Date
+		other Date
+		want  bool
+	}{
+		{
+			name:  "this before other",
+			this:  Date{v: "2023-05-20", present: true, initialized: true},
+			other: Date{v: "2023-05-22", present: true, initialized: true},
+			want:  true,
+		},
+		{
+			name:  "this not before other",
+			this:  Date{v: "2023-05-30", present: true, initialized: true},
+			other: Date{v: "2023-05-22", present: true, initialized: true},
+			want:  false,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := tt.this.Before(tt.other)
+			if err != nil {
+				t.Errorf("Date.Before(): error = %v", err)
+			}
+			if got != tt.want {
+				t.Errorf("Date.Before(): got = %v, want = %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestDate_BeforeErr(t *testing.T) {
+	tests := []struct {
+		name  string
+		this  Date
+		other Date
+	}{
+		{
+			name:  "nil",
+			this:  Date{present: false, initialized: true},
+			other: Date{v: "2023-05-22", present: true, initialized: true},
+		},
+		{
+			name:  "malformed this",
+			this:  Date{v: "20230525", present: true, initialized: true},
+			other: Date{v: "2023-05-26", present: true, initialized: true},
+		},
+		{
+			name:  "malformed other",
+			this:  Date{v: "2023-05-25", present: true, initialized: true},
+			other: Date{v: "20230526", present: true, initialized: true},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			_, err := tt.this.Before(tt.other)
+			if err == nil {
+				t.Errorf("Date.Before(): got nil when expected error")
+			}
+		})
+	}
+}
+
+func TestDate_After(t *testing.T) {
+	tests := []struct {
+		name  string
+		this  Date
+		other Date
+		want  bool
+	}{
+		{
+			name:  "this after other",
+			this:  Date{v: "2023-05-30", present: true, initialized: true},
+			other: Date{v: "2023-05-22", present: true, initialized: true},
+			want:  true,
+		},
+		{
+			name:  "this not after other",
+			this:  Date{v: "2023-05-20", present: true, initialized: true},
+			other: Date{v: "2023-05-22", present: true, initialized: true},
+			want:  false,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := tt.this.After(tt.other)
+			if err != nil {
+				t.Errorf("Date.After(): error = %v", err)
+			}
+			if got != tt.want {
+				t.Errorf("Date.After(): got = %v, want = %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestDate_AfterErr(t *testing.T) {
+	tests := []struct {
+		name  string
+		this  Date
+		other Date
+	}{
+		{
+			name:  "nil",
+			this:  Date{present: false, initialized: true},
+			other: Date{v: "2023-05-22", present: true, initialized: true},
+		},
+		{
+			name:  "malformed this",
+			this:  Date{v: "20230525", present: true, initialized: true},
+			other: Date{v: "2023-05-26", present: true, initialized: true},
+		},
+		{
+			name:  "malformed other",
+			this:  Date{v: "2023-05-25", present: true, initialized: true},
+			other: Date{v: "20230526", present: true, initialized: true},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			_, err := tt.this.After(tt.other)
+			if err == nil {
+				t.Errorf("Date.After(): got nil when expected error")
+			}
+		})
+	}
+}
+
 func TestDate_String(t *testing.T) {
 	tests := []struct {
 		name string


### PR DESCRIPTION
Adds helpful utility methods `Time()`, `Before()` and `After()` to `Date` type. The latter two are meant to provide similar functionality as standard library's [time.Before](https://pkg.go.dev/time#Time.Before) and [time.After](https://pkg.go.dev/time#Time.After) methods.

Added tests!
