### PR TITLE
Bump go version, switch json package

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,5 @@
 
 # Output of the go coverage tool, specifically when used with LiteIDE
 *.out
+
+.DS_Store

--- a/bool.go
+++ b/bool.go
@@ -17,10 +17,10 @@ package nillabletypes
 import (
 	"bytes"
 	"database/sql/driver"
-	"encoding/json"
 	"strconv"
 
 	"github.com/pkg/errors"
+	"github.com/segmentio/encoding/json"
 )
 
 // Bool represents a nil-able bool

--- a/date.go
+++ b/date.go
@@ -17,11 +17,11 @@ package nillabletypes
 import (
 	"bytes"
 	"database/sql/driver"
-	"encoding/json"
 	"regexp"
 	"time"
 
 	"github.com/pkg/errors"
+	"github.com/segmentio/encoding/json"
 )
 
 // TODO(faulkner): technically this is incorrect since it'll match "2000-12-3456789"; useful if we want to trim the time from a datetime, but if we don't have that usecase then perhaps this should be more strict.

--- a/float.go
+++ b/float.go
@@ -17,10 +17,10 @@ package nillabletypes
 import (
 	"bytes"
 	"database/sql/driver"
-	"encoding/json"
 	"strconv"
 
 	"github.com/pkg/errors"
+	"github.com/segmentio/encoding/json"
 )
 
 // Float represents a nil-able float

--- a/float_test.go
+++ b/float_test.go
@@ -16,11 +16,12 @@ package nillabletypes
 
 import (
 	"database/sql/driver"
-	"encoding/json"
 	"fmt"
 	"reflect"
 	"testing"
 	"time"
+
+	"github.com/segmentio/encoding/json"
 )
 
 func TestNewFloat(t *testing.T) {

--- a/go.mod
+++ b/go.mod
@@ -1,5 +1,13 @@
 module github.com/housecanary/nillabletypes
 
-go 1.13
+go 1.21
 
-require github.com/pkg/errors v0.8.1
+require (
+	github.com/pkg/errors v0.8.1
+	github.com/segmentio/encoding v0.4.0
+)
+
+require (
+	github.com/segmentio/asm v1.1.3 // indirect
+	golang.org/x/sys v0.0.0-20220722155257-8c9f86f7a55f // indirect
+)

--- a/go.sum
+++ b/go.sum
@@ -1,2 +1,8 @@
 github.com/pkg/errors v0.8.1 h1:iURUrRGxPUNPdy5/HRSm+Yj6okJ6UtLINN0Q9M4+h3I=
 github.com/pkg/errors v0.8.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
+github.com/segmentio/asm v1.1.3 h1:WM03sfUOENvvKexOLp+pCqgb/WDjsi7EK8gIsICtzhc=
+github.com/segmentio/asm v1.1.3/go.mod h1:Ld3L4ZXGNcSLRg4JBsZ3//1+f/TjYl0Mzen/DQy1EJg=
+github.com/segmentio/encoding v0.4.0 h1:MEBYvRqiUB2nfR2criEXWqwdY6HJOUrCn5hboVOVmy8=
+github.com/segmentio/encoding v0.4.0/go.mod h1:/d03Cd8PoaDeceuhUUUQWjU0KhWjrmYrWPgtJHYZSnI=
+golang.org/x/sys v0.0.0-20220722155257-8c9f86f7a55f h1:v4INt8xihDGvnrfjMDVXGxw9wrfxYyCjk0KbXjhR55s=
+golang.org/x/sys v0.0.0-20220722155257-8c9f86f7a55f/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=

--- a/int32.go
+++ b/int32.go
@@ -17,11 +17,11 @@ package nillabletypes
 import (
 	"bytes"
 	"database/sql/driver"
-	"encoding/json"
 	"math"
 	"strconv"
 
 	"github.com/pkg/errors"
+	"github.com/segmentio/encoding/json"
 )
 
 // Int32 represents a nil-able int

--- a/int64.go
+++ b/int64.go
@@ -17,11 +17,11 @@ package nillabletypes
 import (
 	"bytes"
 	"database/sql/driver"
-	"encoding/json"
 	"math"
 	"strconv"
 
 	"github.com/pkg/errors"
+	"github.com/segmentio/encoding/json"
 )
 
 // Int64 represents a nil-able int

--- a/string.go
+++ b/string.go
@@ -17,9 +17,9 @@ package nillabletypes
 import (
 	"bytes"
 	"database/sql/driver"
-	"encoding/json"
 
 	"github.com/pkg/errors"
+	"github.com/segmentio/encoding/json"
 )
 
 // String represents a nil-able string

--- a/uint32.go
+++ b/uint32.go
@@ -17,11 +17,11 @@ package nillabletypes
 import (
 	"bytes"
 	"database/sql/driver"
-	"encoding/json"
 	"math"
 	"strconv"
 
 	"github.com/pkg/errors"
+	"github.com/segmentio/encoding/json"
 )
 
 // Uint32 represents a nil-able int


### PR DESCRIPTION
- use a more efficient json package
- bump go version from archaic 1.13 